### PR TITLE
Add env as job variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      RELEVANCE_PROJECT: ${{ secrets.RELEVANCE_PROJECT }}
+      RELEVANCE_API_URL: ${{ secrets.RELEVANCE_API_URL }}
+      FUN_RELEVANCE_PROJECT: ${{ secrets.FUN_RELEVANCE_PROJECT }}
+      FUN_RELEVANCE_API_URL: ${{ secrets.FUN_RELEVANCE_API_URL }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -31,7 +36,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEVANCE_PROJECT: ${{ secrets.RELEVANCE_PROJECT }}
-          RELEVANCE_API_URL: ${{ secrets.RELEVANCE_API_URL }}
-          FUN_RELEVANCE_PROJECT: ${{ secrets.FUN_RELEVANCE_PROJECT }}
-          FUN_RELEVANCE_API_URL: ${{ secrets.FUN_RELEVANCE_API_URL }}


### PR DESCRIPTION
As per https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow, I think the env needs to be available on the job.
